### PR TITLE
If gif file url contains a GET parameter the extension is wrong

### DIFF
--- a/freezeframe.js
+++ b/freezeframe.js
@@ -134,6 +134,7 @@ FreezeFrame = (function($) {
 			// Determine file extension
 			ext = $(this)[0].src.split(".");
 			ext = ext[ext.length - 1].toLowerCase();
+			ext = ext.split("?")[0];
 			// Remove non GIF files
 			if(ext !== "gif") {
 				images.splice(index, 1);


### PR DESCRIPTION
For example, drupal add get parameter to filename to deal with browser cache system : 
`
http://mywebsite.com/blandit-obruo-sit-voco_0.gif?itok=GDQd3gUS
`
With this url, the extension is *gif?itok=GDQd3gUS*, and the freezeframe is not working.

PR attached
